### PR TITLE
Queue messages until component has initialized

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -34,6 +34,7 @@
     "purescript-freeap": "^2.0.0",
     "purescript-maps": "^2.0.0",
     "purescript-nullable": "^2.0.0",
+    "purescript-parallel": "^2.1.0",
     "purescript-profunctor": "^2.0.0",
     "purescript-unsafe-coerce": "^2.0.0"
   }

--- a/examples/lifecycle/src/Child.purs
+++ b/examples/lifecycle/src/Child.purs
@@ -2,7 +2,7 @@ module Child where
 
 import Prelude
 
-import Control.Monad.Aff (Aff)
+import Control.Monad.Aff (Aff, later')
 import Control.Monad.Aff.Console (log)
 import Control.Monad.Eff.Console (CONSOLE)
 
@@ -55,7 +55,9 @@ child initialState = H.lifecycleParentComponent
   eval :: Query ~> H.ParentDSL Int Query Query Int Message (ChildEff eff)
   eval (Initialize next) = do
     id <- H.get
-    H.liftAff $ log ("Initialize Child " <> show id)
+    H.lift $ do
+      later' 100 $ pure unit
+      log ("Initialize Child " <> show id)
     H.raise Initialized
     pure next
   eval (Finalize next) = do
@@ -100,7 +102,9 @@ cell initialState = H.lifecycleComponent
   eval :: Query ~> H.ComponentDSL Int Query Message (ChildEff eff)
   eval (Initialize next) = do
     id <- H.get
-    H.liftAff $ log ("Initialize Cell " <> show id)
+    H.lift $ do
+      later' 150 $ pure unit
+      log ("Initialize Cell " <> show id)
     H.raise Initialized
     pure next
   eval (Ref _ next) = do

--- a/src/Halogen/Aff/Driver.purs
+++ b/src/Halogen/Aff/Driver.purs
@@ -296,11 +296,10 @@ runUI renderSpec component = _.driver <$> do
   handlePending ref = do
     DriverState (dsi@{ pendingIn }) <- takeVar ref
     putVar ref (DriverState dsi { pendingIn = Nothing })
-    for_ pendingIn (sequence <<< L.reverse)
+    for_ pendingIn (forkAll <<< L.reverse)
     DriverState (dso@{ pendingOut, handler }) <- takeVar ref
     putVar ref (DriverState dso { pendingOut = Nothing })
-    for_ pendingOut (traverse_ handler <<< L.reverse)
-
+    for_ pendingOut (forkAll <<< map handler <<< L.reverse)
 
   addFinalizer
     :: forall f'

--- a/src/Halogen/Aff/Driver/State.purs
+++ b/src/Halogen/Aff/Driver/State.purs
@@ -13,6 +13,7 @@ import Control.Monad.Aff (Aff)
 import Control.Monad.Aff.AVar (AVar, putVar, makeVar)
 import Control.Monad.Eff.Ref (Ref)
 
+import Data.List (List(..))
 import Data.Map as M
 import Data.Maybe (Maybe(..))
 
@@ -51,6 +52,8 @@ type DriverStateRec h r s f g p o eff =
   , mkOrdBox :: p -> OrdBox p
   , selfRef :: AVar (DriverState h r s f g p o eff)
   , handler :: o -> Aff (HalogenEffects eff) Unit
+  , pendingIn :: Maybe (List (Aff (HalogenEffects eff) Unit))
+  , pendingOut :: Maybe (List o)
   , keyId :: Int
   , fresh :: Ref Int
   , rendering :: Maybe r
@@ -94,6 +97,8 @@ initDriverState component componentType handler keyId fresh = do
       , keyId
       , fresh
       , handler
+      , pendingIn: component.initializer $> Nil
+      , pendingOut: component.initializer $> Nil
       , rendering: Nothing
       }
   putVar selfRef (DriverState ds)


### PR DESCRIPTION
@natefaubion Here's the sequence reported from the `Lifecycle` example now when adding:

```
Ref Cell 0
Ref Cell 1
Ref Cell 2
Ref Child 0
Initialize Cell 0
Initialize Cell 1
Initialize Cell 2
Initialize Child 0
Child 0 >>> Heard Refd from cell0
Child 0 >>> Heard Initialized from cell0
Child 0 >>> Heard Refd from cell1
Child 0 >>> Heard Initialized from cell1
Child 0 >>> Heard Refd from cell2
Child 0 >>> Heard Initialized from cell2
Root >>> Heard Refd from child0
Root >>> Heard Initialized from child0
Root >>> Re-reporting from child0: Heard Refd from cell0
Root >>> Re-reporting from child0: Heard Initialized from cell0
Root >>> Re-reporting from child0: Heard Refd from cell1
Root >>> Re-reporting from child0: Heard Initialized from cell1
Root >>> Re-reporting from child0: Heard Refd from cell2
Root >>> Re-reporting from child0: Heard Initialized from cell2
```

The queuing works in two places:
1. a component will not emit any messages of its own until it has initialized
2. a component will not handle any messages from a child until it has initialzed

And things are handled in that order too, so in the log above you can see the messages `raise`d from the child are heard at the root before the messages that were originally raised by a cell.

Does that seem sensible? It kinda doesn't matter which way round the queues are processed, we could emit the messages that arose before init for a component first and it would still work out, because either way, if you hear a message from a component then you know it has initialized, so querying it is safe.
