### PR TITLE
Fix `awaitBody`

### DIFF
--- a/src/Halogen/Aff/Util.purs
+++ b/src/Halogen/Aff/Util.purs
@@ -1,5 +1,7 @@
 module Halogen.Aff.Util
-  ( awaitLoad
+  ( awaitReady
+  , awaitLoad
+  , awaitElement
   , awaitBody
   , selectElement
   , runHalogenAff
@@ -7,7 +9,8 @@ module Halogen.Aff.Util
 
 import Prelude
 
-import Control.Monad.Aff (Aff, Canceler(..), makeAff, runAff_)
+import Control.Alt ((<|>))
+import Control.Monad.Aff (Aff, Canceler(..), makeAff, nonCanceler, runAff_)
 import Control.Monad.Eff (kind Effect, Eff)
 import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Exception (throwException, error)
@@ -16,29 +19,56 @@ import Control.Monad.Except (runExcept)
 import DOM (DOM)
 import DOM.Event.EventTarget (addEventListener, eventListener, removeEventListener)
 import DOM.HTML (window)
-import DOM.HTML.Event.EventTypes (load)
-import DOM.HTML.Types (HTMLElement, windowToEventTarget, htmlDocumentToParentNode, readHTMLElement)
+import DOM.HTML.Event.EventTypes (readystatechange)
+import DOM.HTML.Types (HTMLElement, htmlDocumentToEventTarget, htmlDocumentToParentNode, readHTMLElement)
 import DOM.HTML.Window (document)
 import DOM.Node.ParentNode (QuerySelector(..), querySelector)
 import Data.Either (Either(..), either)
 import Data.Foreign (toForeign)
 import Data.Maybe (Maybe(..), maybe)
 import Halogen.Aff.Effects (HalogenEffects)
+import Unsafe.Coerce (unsafeCoerce)
+
+documentReadyState :: forall eff. Eff (dom :: DOM | eff) String
+documentReadyState = do
+  doc <- document =<< window
+  pure (unsafeCoerce doc).readyState
+
+awaitReadyState :: forall eff. String -> Aff (dom :: DOM | eff) Unit
+awaitReadyState state = isState <|> awaitState
+  where
+    isState = makeAff \cb -> do
+      drs <- documentReadyState
+      if drs == state
+        then cb (Right unit)
+        else cb (Left $ error "Not ready yet")
+      pure nonCanceler
+    awaitState = makeAff \cb -> do
+      et <- htmlDocumentToEventTarget <$> (document =<< window)
+      let listener = eventListener \_ -> do
+            removeEventListener readystatechange listener false et
+            runAff_ cb (awaitReadyState state)
+      addEventListener readystatechange listener false et
+      pure $ Canceler \_ -> liftEff $ removeEventListener readystatechange listener false et
+
+-- | Waits for the document to become interactive.
+awaitReady :: forall eff. Aff (dom :: DOM | eff) Unit
+awaitReady = awaitReadyState "interactive"
 
 -- | Waits for the document to load.
 awaitLoad :: forall eff. Aff (dom :: DOM | eff) Unit
-awaitLoad = makeAff \callback -> liftEff do
-  et <- windowToEventTarget <$> window
-  let listener = eventListener (\_ -> callback (Right unit))
-  addEventListener load listener false et
-  pure $ Canceler \_ -> liftEff (removeEventListener load listener false et)
+awaitLoad = awaitReadyState "complete"
 
--- | Waits for the document to load and then finds the `body` element.
+-- | Waits for the document to be ready and then finds the given element.
+awaitElement :: forall eff. QuerySelector -> Aff (dom :: DOM | eff) HTMLElement
+awaitElement query = do
+  awaitReady
+  body <- selectElement query
+  maybe (throwError $ error "Could not find body") pure body
+
+-- | Waits for the document to be ready and then finds the `body` element.
 awaitBody :: forall eff. Aff (dom :: DOM | eff) HTMLElement
-awaitBody = do
-  awaitLoad
-  body <- selectElement (QuerySelector "body")
-  maybe (throwError (error "Could not find body")) pure body
+awaitBody = awaitElement (QuerySelector "body")
 
 -- | Tries to find an element in the document.
 selectElement


### PR DESCRIPTION
I abstracted things a tiny bit to allow awaiting for elements and to fix the race condition.  I left a function for awaiting the "load" event, but all the more specific helpers await "DOMContentLoaded" instead.  This is significantly faster while still waiting long enough to interact with the DOM.